### PR TITLE
Fix pivot bug in MV

### DIFF
--- a/KC_MoveRouteTF.js
+++ b/KC_MoveRouteTF.js
@@ -193,6 +193,16 @@ Sprite_Character.prototype.updateOther = function () {
     }
 };
 
+// Calling refresh resets the pivot, so let's un-reset it 
+//(fixes animations causing the character sprite to be offset)
+KCDev.MoveRouteTF.Sprite_Character__refresh = Sprite_Character.prototype._refresh;
+Sprite_Character.prototype._refresh = function () {
+    KCDev.MoveRouteTF.Sprite_Character__refresh.apply(this, arguments);
+    if (KCDev.MoveRouteTF.parameters.enableRot) {
+        this.pivot.y = -this.patternHeight() / 2;
+    }
+};
+
 KCDev.MoveRouteTF.Game_CharacterBase_initMembers = Game_CharacterBase.prototype.initMembers;
 Game_CharacterBase.prototype.initMembers = function () {
     KCDev.MoveRouteTF.Game_CharacterBase_initMembers.apply(this, arguments);


### PR DESCRIPTION
Calling "Show Animation" on a character in MV calls the _refresh function which also resets the pivot. This function simply sets the pivot back to the desired value after _refresh is called